### PR TITLE
Bugfixes to go-scgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ for basic scgi operation.
 There are two main ways to use this package. It can be used directly as a
 net/http.Client's RoundTripper or it can be added to a net/http.Transport
 using RegisterProtocol.
+
+```go
+t := &http.Transport{}
+t.RegisterProtocol("scgi", &scgi.Client{})
+client := &http.Client{Transport: t}
+req, err := http.NewRequest("GET", "scgi:////run/scgi.sock", nil)
+resp, err := client.Do(req)
+```
+
+The URI used in the request only specifies the path to the socket file.
+To communicate with the server, add CGI parameters as request headers.
+
+```go
+req.Header.Set("REMOTE_ADDR", "127.0.0.1")
+req.Header.Set("REQUEST_URI", "/resource?foo=bar")
+req.Header.Set("QUERY_STRING", "foo=bar")
+```

--- a/scgi.go
+++ b/scgi.go
@@ -90,9 +90,13 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("scgi: round trip: invalid scgi connection string")
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "scgi: round trip: body read error")
+	var data []byte
+	var err error
+	if req.Body != nil {
+		data, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "scgi: round trip: body read error")
+		}
 	}
 
 	var scgiConn net.Conn

--- a/scgi.go
+++ b/scgi.go
@@ -132,7 +132,7 @@ func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Write additional headers
 	for key, val := range req.Header {
-		headerBuf.WriteString(key)
+		headerBuf.WriteString(strings.ToUpper(key))
 		headerBuf.Write([]byte{0x00})
 		headerBuf.WriteString(strings.Join(val, ","))
 		headerBuf.Write([]byte{0x00})


### PR DESCRIPTION
Hi!

I ran into a couple of issues when trying to use go-scgi in a project. Here are patches to fix them:

* When sending a GET request, I got a crash trying to read from a nil req.Body object.
* When sending the CGI headers, they were not sent in all-uppercase, and my SCGI client didn't understand them.

I have also added some lines to the README to give some code examples on how to use the library, as it took me some time to figure it out...